### PR TITLE
Moon illumination is a decimal % now

### DIFF
--- a/weer_api/src/models/forecast.rs
+++ b/weer_api/src/models/forecast.rs
@@ -95,7 +95,7 @@ pub struct Astro {
     pub moonrise: String,
     pub moonset: String,
     pub moon_phase: MoonPhase,
-    pub moon_illumination: String
+    pub moon_illumination: u8,
 }
 
 impl Astro {


### PR DESCRIPTION
Not sure when this changed, but it's mentioned in the [API docs](https://www.weatherapi.com/docs/#apis-astronomy)